### PR TITLE
Refactoring to use chained batch instead of array batch.

### DIFF
--- a/level-ws.js
+++ b/level-ws.js
@@ -124,6 +124,10 @@ WriteStream.prototype._flush = function (f) {
   self._batch = null
 
   batch.write(function cb(err) {
+    // keep a reference to the Batch
+    // to avoid it being collected by the GC
+    // otherwise SEGFAULT!
+    batch.done = true
     if (err) {
       self.writable = false
       self.emit('error', err)


### PR DESCRIPTION
All the work being done in https://github.com/rvagg/node-levelup/issues/171 by @brycebaril shows that using chained batch is much better then using array batch.

I'm trying this for https://github.com/mcollina/levelgraph/issues/40.

However I'm getting some segfaults under heavy load.

I also got this error:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
WriteError: Corruption: WriteBatch has wrong count
    at /Users/matteo/Temp/lg-mem-leak/node_modules/level-hyper/node_modules/level-packager/node_modules/levelup/lib/batch.js:68:39
```
