### PR TITLE
Remove buffer.map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Flip parameters in `WriteStream` constructor (@ralphtheninja)
 * Verify results once using `level-concat-iterator` intead of multiple `db.get()` operations (@ralphtheninja)
 * Update README style (@ralphtheninja)
+* Optimize internal batch `_buffer` by pushing transformed data (@ralphtheninja)
 
 ### Added
 * Add node 6, 8, 9 and 10 to Travis (@ralphtheninja)

--- a/level-ws.js
+++ b/level-ws.js
@@ -40,10 +40,7 @@ WriteStream.prototype._write = function (d, enc, next) {
     self._buffer.push({
       type: d.type || self._options.type,
       key: d.key,
-      value: d.value,
-      keyEncoding: d.keyEncoding || self._options.keyEncoding,
-      valueEncoding: (d.valueEncoding || d.encoding ||
-                      self._options.valueEncoding)
+      value: d.value
     })
     next()
   }

--- a/level-ws.js
+++ b/level-ws.js
@@ -41,9 +41,8 @@ WriteStream.prototype._write = function (d, enc, next) {
       type: d.type || self._options.type,
       key: d.key,
       value: d.value,
-      keyEncoding: d.keyEncoding || self._options.keyEncoding,
-      valueEncoding: (d.valueEncoding || d.encoding ||
-                      self._options.valueEncoding)
+      keyEncoding: d.keyEncoding,
+      valueEncoding: d.valueEncoding || d.encoding
     })
     next()
   }

--- a/level-ws.js
+++ b/level-ws.js
@@ -37,7 +37,14 @@ WriteStream.prototype._write = function (d, enc, next) {
       self._flushing = true
       process.nextTick(function () { self._flush() })
     }
-    self._buffer.push(d)
+    self._buffer.push({
+      type: d.type || self._options.type,
+      key: d.key,
+      value: d.value,
+      keyEncoding: d.keyEncoding || self._options.keyEncoding,
+      valueEncoding: (d.valueEncoding || d.encoding ||
+                      self._options.valueEncoding)
+    })
     next()
   }
 }
@@ -49,17 +56,7 @@ WriteStream.prototype._flush = function () {
   if (self.destroyed || !buffer) return
 
   self._buffer = []
-
-  self._db.batch(buffer.map(function (d) {
-    return {
-      type: d.type || self._options.type,
-      key: d.key,
-      value: d.value,
-      keyEncoding: d.keyEncoding || self._options.keyEncoding,
-      valueEncoding: (d.valueEncoding || d.encoding ||
-                      self._options.valueEncoding)
-    }
-  }), cb)
+  self._db.batch(buffer, cb)
 
   function cb (err) {
     self._flushing = false

--- a/level-ws.js
+++ b/level-ws.js
@@ -40,7 +40,10 @@ WriteStream.prototype._write = function (d, enc, next) {
     self._buffer.push({
       type: d.type || self._options.type,
       key: d.key,
-      value: d.value
+      value: d.value,
+      keyEncoding: d.keyEncoding || self._options.keyEncoding,
+      valueEncoding: (d.valueEncoding || d.encoding ||
+                      self._options.valueEncoding)
     })
     next()
   }


### PR DESCRIPTION
Push transformed data directly to internal buffer instead of doing `buffer.map()`.