### PR TITLE
Change maxBufferLength to pause rather than drop writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .nyc_output
+coverage

--- a/level-ws.js
+++ b/level-ws.js
@@ -9,9 +9,14 @@ function WriteStream (db, options) {
     return new WriteStream(db, options)
   }
 
-  Writable.call(this, { objectMode: true })
+  options = extend(defaultOptions, options)
 
-  this._options = extend(defaultOptions, options)
+  Writable.call(this, {
+    objectMode: true,
+    highWaterMark: options.highWaterMark || 16
+  })
+
+  this._options = options
   this._db = db
   this._buffer = []
   this._flushing = false


### PR DESCRIPTION
Closes #83.

The approach I suggested in https://github.com/Level/level-ws/issues/83#issuecomment-401539523 (pushing to the buffer on every `_write` regardless of `maxBufferLength `) didn't work out because if a flush was already scheduled, pushing to the buffer will make it spill (doing batches that are `maxBufferLength + x` in length).