### PR TITLE
Replace xtend with Object.assign

### DIFF
--- a/level-ws.js
+++ b/level-ws.js
@@ -1,6 +1,5 @@
 var Writable = require('readable-stream').Writable
 var inherits = require('inherits')
-var extend = require('xtend')
 
 var defaultOptions = { type: 'put' }
 
@@ -9,7 +8,7 @@ function WriteStream (db, options) {
     return new WriteStream(db, options)
   }
 
-  options = extend(defaultOptions, options)
+  options = Object.assign({}, defaultOptions, options)
 
   Writable.call(this, {
     objectMode: true,
@@ -46,7 +45,7 @@ WriteStream.prototype._write = function (data, enc, next) {
       self._write(data, enc, next)
     })
   } else {
-    self._buffer.push(extend({ type: self._options.type }, data))
+    self._buffer.push(Object.assign({}, { type: self._options.type }, data))
     next()
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "inherits": "^2.0.3",
     "readable-stream": "^2.2.8",
-    "xtend": "^4.0.1"
   },
   "devDependencies": {
     "coveralls": "~3.0.1",


### PR DESCRIPTION
- Object.assign is supported in Node 4+ and can replace `xtend` package
- Updated package.json to remove xtend